### PR TITLE
Suggested changes

### DIFF
--- a/command/file_runner.go
+++ b/command/file_runner.go
@@ -31,7 +31,9 @@ func NewFileRunner(filename string, config *config.TfmigrateConfig, option *tfmi
 		return nil, err
 	}
 
-	m, err := mc.Migrator.NewMigrator(option, config.IsBackendTerraformCloud)
+	option.IsBackendTerraformCloud = config.IsBackendTerraformCloud
+
+	m, err := mc.Migrator.NewMigrator(option)
 
 	if err != nil {
 		return nil, err

--- a/tfmigrate/config.go
+++ b/tfmigrate/config.go
@@ -14,7 +14,7 @@ type MigrationConfig struct {
 // MigratorConfig is an interface of factory method for Migrator.
 type MigratorConfig interface {
 	// NewMigrator returns a new instance of Migrator.
-	NewMigrator(o *MigratorOption, isBackendTerraformCloud bool) (Migrator, error)
+	NewMigrator(o *MigratorOption) (Migrator, error)
 }
 
 // MigratorOption customizes a behavior of Migrator.
@@ -27,4 +27,7 @@ type MigratorOption struct {
 
 	// PlanOut is a path to plan file to be saved.
 	PlanOut string
+
+	// IsBackendTerraformCloud is a boolean indicating if the remote backend is Terraform Cloud
+	IsBackendTerraformCloud bool
 }

--- a/tfmigrate/mock_migrator.go
+++ b/tfmigrate/mock_migrator.go
@@ -20,7 +20,7 @@ type MockMigratorConfig struct {
 var _ MigratorConfig = (*MockMigratorConfig)(nil)
 
 // NewMigrator returns a new instance of MockMigrator.
-func (c *MockMigratorConfig) NewMigrator(o *MigratorOption, isBackendTerraformCloud bool) (Migrator, error) {
+func (c *MockMigratorConfig) NewMigrator(o *MigratorOption) (Migrator, error) {
 	return NewMockMigrator(c.PlanError, c.ApplyError), nil
 }
 


### PR DESCRIPTION
Use migrator options for storing `IsBackendTerraformCloud` as opposed to changing interface.